### PR TITLE
Remove dependency to uhd/utils/atomic.hpp

### DIFF
--- a/apps/record/specrec.cpp
+++ b/apps/record/specrec.cpp
@@ -33,7 +33,7 @@
 #include <complex>
 #include <ctime>
 #include <boost/atomic.hpp>
-#include <uhd/utils/atomic.hpp>
+//#include <uhd/utils/atomic.hpp>
 // need PMT for metadata headers
 #include <pmt/pmt.h>
 //pthread lib


### PR DESCRIPTION
This dependency seems no longer necessary since the following line
//uhd::time_spec_t timestamp = uhd::time_spec_t::get_system_time();
was commented in commit db6454fb35530b9ce46aa0cf6b6dce101af3fecd.